### PR TITLE
Assetic.options undefined index notice fix

### DIFF
--- a/doc/assetic.rst
+++ b/doc/assetic.rst
@@ -8,11 +8,9 @@ library.
 Parameters
 ----------
 
-* **assetic.options**: An associative array of assetic
-  options.
+* **assetic.path_to_web**: Location where to dump all generated files
 
-* **assetic.options => path_to_web**: Location where to dump
-  all generated files
+* **assetic.options**: An associative array of assetic options.
 
 * **assetic.options => debug** (defaults to false, optional): 
 
@@ -74,8 +72,9 @@ directory.
 
     $app->register(new Silex\Extension\AsseticExtension(), array(
         'assetic.class_path' => __DIR__.'/vendor/assetic/src',
+        'assetic.path_to_web' => __DIR__ . '/assets',
         'assetic.options' => array(
-            'path_to_web'           => __DIR__ . '/assets'
+        	'debug' => TRUE
         ),
         'assetic.filters' => $app->protect(function($fm) {
             $fm->set('yui_css', new Assetic\Filter\Yui\CssCompressorFilter(

--- a/example/assetic.php
+++ b/example/assetic.php
@@ -13,11 +13,10 @@ $app->register(new Silex\Extension\TwigExtension(), array(
 $app['autoloader']->registerNamespace('SilexExtension', __DIR__ . '/../src');
 $app->register(new SilexExtension\AsseticExtension(), array(
     'assetic.class_path' => __DIR__.'/../vendor/assetic/src',
+    'assetic.path_to_web' => __DIR__ . '/assetic/output',
     'assetic.options' => array(
-        'formulae_cache_dir'     => __DIR__ . '/assetic/cache',
-        'twig_support'  => true,
-        'path_to_web'   => __DIR__ . '/assetic/output',
-        'debug'         => false
+        'formulae_cache_dir' => __DIR__ . '/assetic/cache',
+        'debug' => false
     ),
     'assetic.filters' => $app->protect(function($fm) {
         $fm->set('yui_css', new Assetic\Filter\Yui\CssCompressorFilter(

--- a/src/SilexExtension/AsseticExtension.php
+++ b/src/SilexExtension/AsseticExtension.php
@@ -18,21 +18,15 @@ class AsseticExtension implements ExtensionInterface
 {
     public function register(Application $app)
     {
-        /**
-         * Default options
-         */
-        $options = array(
-            'debug'         => false,
+        $app['assetic.options'] = array_replace(array(
+            'debug' => false,
             'formulae_cache_dir' => null,
-        );
-
+        ), isset($app['assetic.options']) ? $app['assetic.options'] : array());
+        
         /**
          * Asset Factory conifguration happens here
          */
-        $app['assetic'] = $app->share(function () use ($app, $options) {
-            $app['assetic.options'] = isset($app['assetic.options'])
-                ? array_merge($options, $app['assetic.options']) : $options;
-
+        $app['assetic'] = $app->share(function () use ($app) {
             // initializing lazy asset manager
             if (isset($app['assetic.formulae']) &&
                !is_array($app['assetic.formulae']) &&

--- a/src/SilexExtension/AsseticExtension.php
+++ b/src/SilexExtension/AsseticExtension.php
@@ -44,10 +44,7 @@ class AsseticExtension implements ExtensionInterface
          */
         $app['assetic.factory'] = $app->share(function() use ($app) {
             $options = $app['assetic.options'];
-            if (!isset($options['path_to_web'])) {
-                throw new \Exception("Missing option 'path_to_web' in assetic.options");
-            }
-            $factory = new AssetFactory($options['path_to_web'], $options['debug']);
+            $factory = new AssetFactory($app['assetic.path_to_web'], $options['debug']);
             $factory->setAssetManager($app['assetic.asset_manager']);
             $factory->setFilterManager($app['assetic.filter_manager']);
             return $factory;
@@ -64,10 +61,10 @@ class AsseticExtension implements ExtensionInterface
         });
 
         /**
-         * Asset writer, writes to the 'path_to_web' folder
+         * Asset writer, writes to the 'assetic.path_to_web' folder
          */
         $app['assetic.asset_writer'] = $app->share(function () use ($app) {
-            return new AssetWriter($app['assetic.options']['path_to_web']);
+            return new AssetWriter($app['assetic.path_to_web']);
         });
 
         /**

--- a/tests/SilexExtension/Tests/AsseticExtension.php
+++ b/tests/SilexExtension/Tests/AsseticExtension.php
@@ -22,9 +22,7 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         $app = new Application();
         $app->register(new AsseticExtension(), array(
             'assetic.class_path' => __DIR__ . '/../../../../vendor/assetic/src',
-            'assetic.options' => array(
-                'path_to_web' => sys_get_temp_dir()
-            )
+            'assetic.path_to_web' => sys_get_temp_dir()
         ));
         $app->get('/', function () use ($app) {
             return 'AsseticExtensionTest';
@@ -45,9 +43,7 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         $app = new Application();
         $app->register(new AsseticExtension(), array(
             'assetic.class_path' => __DIR__ . '/../../../../vendor/assetic/src',
-            'assetic.options' => array(
-                'path_to_web' => sys_get_temp_dir()
-            ),
+            'assetic.path_to_web' => sys_get_temp_dir(),
             'assetic.filters' => $app->protect(function($fm) {
                 $fm->set('test_filter', new \Assetic\Filter\CssMinFilter());
             })
@@ -68,9 +64,7 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         $app = new Application();
         $app->register(new AsseticExtension(), array(
             'assetic.class_path' => __DIR__ . '/../../../../vendor/assetic/src',
-            'assetic.options' => array(
-                'path_to_web' => sys_get_temp_dir()
-            ),
+            'assetic.path_to_web' => sys_get_temp_dir(),
             'assetic.assets' => $app->protect(function($am) {
                 $asset = new \Assetic\Asset\FileAsset(__FILE__);
                 $asset->setTargetUrl(md5(__FILE__));


### PR DESCRIPTION
Hey again, AsseticExtension was throwing an undefined index notice when twig was enabled because $app['assetic.options'] is not ready when $app['assetic.factory'] tries to access it. I moved the options initialization outside of the $app['assetic'] closure which I believe this fixes the issue without any problems.

Also, as a possible improvement, I've attached a second commit that moves the 'path_to_web' option to it's own level. I think this more closely resembles the configuration of the other core Extensions since it is a required setting. Hope this helps!

This is my first pull request btw so I really hope I don't break GitHub.
