### PR TITLE
Travis and Composer Integration, some fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ functions.php
 vendor/
 .redcar
 silex.phar
+composer.phar
 example/odm/Model
 example/assetic/output/*
 example/assetic/cache/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  
+before_script:
+  - "sh bin/travis-init.sh"

--- a/README.rst
+++ b/README.rst
@@ -26,18 +26,20 @@ Extensions with Twig Support
 Installation
 ------------
 
-Run the following commands inside your Silex directory:
+Create a composer.json in your projects root-directory
 
-    git clone git@github.com:fate/Silex-Extensions.git vendor/silex-extension
-    
-To install vendor depedencies, copy vendors.sh in your root directory and run 
+    {
+        "require": {
+            "fate/Silex-Extensions": "*"
+        }
+    }
 
-    sh ./vendors.sh
-    
-And install all submodules in vendor/mongodb and vendor/mandango
+and run
 
-    git submodule update --init
- 
+    curl -s http://getcomposer.org/installer | php
+    php composer.phar install
+
+
 Add the library to the Silex autoloader
 
     $app['autoloader']->registerNamespace('SilexExtension', __DIR__ . '/vendor/silex-extension/src');

--- a/bin/travis-init.sh
+++ b/bin/travis-init.sh
@@ -1,0 +1,21 @@
+# installing memcached extension
+curl -s http://pecl.php.net/get/memcached-2.0.1.tgz > memcached-2.0.1.tgz
+tar -xzf memcached-2.0.1.tgz
+sh -c "cd memcached-2.0.1 && phpize && ./configure && make && sudo make install"
+echo "extension=memcached.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+
+curl -s http://pecl.php.net/get/memcache-2.2.6.tgz > memcache-2.2.6.tgz
+tar -xzf memcache-2.2.6.tgz
+sh -c "cd memcache-2.2.6 && phpize && ./configure && make && sudo make install"
+echo "extension=memcache.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+
+# installing mongo extension
+curl -s http://pecl.php.net/get/mongo-1.2.9.tgz > mongo-1.2.9.tgz
+tar -xzf mongo-1.2.9.tgz
+sh -c "cd mongo-1.2.9 && phpize && ./configure && make && sudo make install"
+echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+
+wget silex-project.org/get/silex.phar
+
+wget http://getcomposer.org/composer.phar
+php composer.phar install

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,124 @@
+{
+    "name": "fate/silex-extensions",
+    "description": "Collection of Extensions for Silex",
+    "keywords": ["silex"],
+    "homepage": "https://github.com/fate/Silex-Extensions",
+    "type": "library",
+    "license": "MIT",
+    "version": "1.0.0",
+    "authors": [
+    {
+        "name": "Sven Eisenschmidt",
+        "email": "sven.eisenschmidt@gmail.com",
+        "homepage": "http://unsicherheitsagent.de/"
+    }
+    ],
+    "repositories": [
+    {
+        "type":"package",
+        "package": {
+            "name":"mandango/mondator",
+            "version":"master",
+            "dist":{
+                "url":"https://github.com/mandango/mondator/zipball/5685054409a76b41c27573e4bc17523f8236551a",
+                "type":"zip"
+            },
+            "source": {
+                "url":"git://github.com/mandango/mondator.git",
+                "type":"git",
+                "reference": "master"
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mandango\\Mondator":"src"
+                }
+            }
+        }
+    },
+    {
+        "type":"package",
+        "package": {
+            "name":"mandango/mandango",
+            "version":"master",
+            "dist":{
+                "url":"https://github.com/mandango/mandango/zipball/957d6c6f54c8ed0762ab63b16a057d1e631bc002",
+                "type":"zip"
+            },
+            "source": {
+                "url":"git://github.com/mandango/mandango.git",
+                "type":"git",
+                "reference": "master"
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mandango\\Mandango":"src"
+                }
+            },
+            "require": {
+                "symfony/class-loader": ">=2.0.0",
+                "twig/twig": ">=1.2",
+                "mandango/mondator": "*"
+            }
+        }
+    },
+    {
+        "type":"package",
+        "package": {
+            "name":"fate/gravatar-php",
+            "version":"master",
+            "dist":{
+                "url":"https://github.com/fate/Gravatar-php/zipball/957d6c6f54c8ed0762ab63b16a057d1e631bc002",
+                "type":"zip"
+            },
+            "source": {
+                "url":"git://github.com/fate/Gravatar-php.git",
+                "type":"git",
+                "reference": "master"
+            },
+            "autoload": {
+                "psr-0": {
+                    "Gravatar":"src"
+                }
+            }
+        }
+    },
+    {
+        "type":"package",
+        "package": {
+            "name":"embedly/embedly-php",
+            "version":"master",
+            "dist":{
+                "url":"https://github.com/embedly/embedly-php/zipball/fc30b795a97fb79af67cf6c23733a439dd94e8d1",
+                "type":"zip"
+            },
+            "source": {
+                "url":"git://github.com/embedly/embedly-php.git",
+                "type":"git",
+                "reference": "master"
+            },
+            "autoload": {
+                "psr-0": {
+                    "Embedly":"src"
+                }
+            }
+        }
+    }
+    ],
+    "require": {
+        "php": ">=5.3.0",
+        "kriswallsmith/assetic": ">=1.0",
+        "twig/twig": ">=1.2.0",
+        "doctrine/mongodb": "*",
+        "predis/predis": "*",
+        "mandango/mandango": "*",
+        "knplabs/knp-markdown-bundle": "*",
+        "embedly/embedly-php": "*",
+        "fate/gravatar-php": "*"
+    },
+    "autoload": {
+        "psr-0": { 
+            "SilexExtension": "src"
+        }
+    }
+    
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,125 @@
+{
+    "hash": "5322ad016699a4eaca7c2538712f4332",
+    "packages": [
+        {
+            "package": "doctrine/common",
+            "version": "2.2.1"
+        },
+        {
+            "package": "doctrine/mongodb",
+            "version": "dev-master",
+            "source-reference": "d7fdcff25b9534e67abbd557bf75250cbef62b31"
+        },
+        {
+            "package": "embedly/embedly-php",
+            "version": "master",
+            "source-reference": "master"
+        },
+        {
+            "package": "fate/gravatar-php",
+            "version": "master",
+            "source-reference": "master"
+        },
+        {
+            "package": "knplabs/knp-markdown-bundle",
+            "version": "dev-master",
+            "source-reference": "8a7637054b945c2fd5fbeece2cf98139fb79d8f3"
+        },
+        {
+            "package": "kriswallsmith/assetic",
+            "version": "dev-master",
+            "source-reference": "2634d29cc193981761e3daf28e1afc6358bb43b1"
+        },
+        {
+            "package": "mandango/mandango",
+            "version": "master",
+            "source-reference": "master"
+        },
+        {
+            "package": "mandango/mondator",
+            "version": "master",
+            "source-reference": "master"
+        },
+        {
+            "package": "predis/predis",
+            "version": "dev-master",
+            "source-reference": "785670dcf77654be0e63be8ff524c375a59498e7"
+        },
+        {
+            "package": "symfony/class-loader",
+            "version": "dev-master",
+            "source-reference": "8bceaa2f1fed52f6285b2cea39e7ae37fbea1c9b"
+        },
+        {
+            "package": "symfony/config",
+            "version": "dev-master",
+            "source-reference": "8674185c90b5373c998e8dbb41128ef1ed0f8acd"
+        },
+        {
+            "package": "symfony/console",
+            "version": "dev-master",
+            "source-reference": "2ee50c7c845ef7f8bce9c540709ecfd64cbcda87"
+        },
+        {
+            "package": "symfony/dependency-injection",
+            "version": "dev-master",
+            "source-reference": "c097d6610a82cec38d4c3876d6215516de151602"
+        },
+        {
+            "package": "symfony/event-dispatcher",
+            "version": "dev-master",
+            "source-reference": "f6b7f60b0c29ab8167de7d7c9ba78fc9cc283c64"
+        },
+        {
+            "package": "symfony/filesystem",
+            "version": "dev-master",
+            "source-reference": "f475e8299ff7bffbbd858bef85d3c80036f13877"
+        },
+        {
+            "package": "symfony/framework-bundle",
+            "version": "dev-master",
+            "source-reference": "6cfca7c62d3574a206439e321601101f4cf55d76"
+        },
+        {
+            "package": "symfony/http-foundation",
+            "version": "dev-master",
+            "source-reference": "2abe7f1b8e0f808dad0cc001b9d69371b604d719"
+        },
+        {
+            "package": "symfony/http-kernel",
+            "version": "dev-master",
+            "source-reference": "cf2bb8655a13fcb516b1d0b95ddf0c51db25b2a8"
+        },
+        {
+            "package": "symfony/process",
+            "version": "dev-master",
+            "source-reference": "6aceac404d8574cf7da57e7e29b00a665b7bd559"
+        },
+        {
+            "package": "symfony/routing",
+            "version": "dev-master",
+            "source-reference": "d3d9c02357b2db6503539d11f6c379ccd86f9cc4"
+        },
+        {
+            "package": "symfony/templating",
+            "version": "dev-master",
+            "source-reference": "e56404d48ed30e9849991f7187f52c887b7e7184"
+        },
+        {
+            "package": "symfony/translation",
+            "version": "dev-master",
+            "source-reference": "b7a4c59a34ce2c7b470e10e22e9bf47e21634156"
+        },
+        {
+            "package": "symfony/yaml",
+            "version": "dev-master",
+            "source-reference": "2552c643a158ee7fb6c52c0dd55806055c575841"
+        },
+        {
+            "package": "twig/twig",
+            "version": "dev-master",
+            "source-reference": "9f322ab2fd21fc70ad58ee62facc0eb5ed2b9db8"
+        }
+    ],
+    "aliases": []
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
+         verbose="true"
          bootstrap="tests/bootstrap.php"
 >
     <testsuites>

--- a/src/SilexExtension/PredisExtension.php
+++ b/src/SilexExtension/PredisExtension.php
@@ -7,7 +7,7 @@ use Silex\Application;
 use Silex\ServiceProviderInterface;
 
 use Predis\Client, 
-    Predis\ClientOptions,
+    Predis\Option\ClientOptions,
     Predis\DispatcherLoop,
     Predis\ConnectionParameters;
 

--- a/tests/SilexExtension/Tests/AsseticExtensionTest.php
+++ b/tests/SilexExtension/Tests/AsseticExtensionTest.php
@@ -12,7 +12,7 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        if (!is_dir(__DIR__ . '/../../../vendor/assetic/src')) {
+        if (!class_exists('Assetic\\AssetManager')) {
             $this->markTestSkipped('Assetic was not installed.');
         }
     }

--- a/tests/SilexExtension/Tests/EmbedlyExtensionTest.php
+++ b/tests/SilexExtension/Tests/EmbedlyExtensionTest.php
@@ -14,7 +14,7 @@ class EmbedlyExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        if (!is_dir(__DIR__ . '/../../../vendor/embedly-php/src')) {
+        if (!class_exists('Embedly\\Embedly')) {
             $this->markTestSkipped('Embedly was not installed.');
         }
     }

--- a/tests/SilexExtension/Tests/GravatarExtensionTest.php
+++ b/tests/SilexExtension/Tests/GravatarExtensionTest.php
@@ -14,7 +14,7 @@ class GravatarExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        if (!is_dir(__DIR__ . '/../../../vendor/gravatar-php/src')) {
+        if (!class_exists('Gravatar\\Service')) {
             $this->markTestSkipped('Gravatar was not installed.');
         }
     }

--- a/tests/SilexExtension/Tests/MarkdownExtensionTest.php
+++ b/tests/SilexExtension/Tests/MarkdownExtensionTest.php
@@ -12,8 +12,8 @@ class MarkdownExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        if (!is_dir(__DIR__ . '/../../../vendor/embedly-php/src')) {
-            $this->markTestSkipped('Embedly was not installed.');
+        if (!class_exists('Knp\\Bundle\\MarkdownBundle\\Parser\\MarkdownParser')) {
+            $this->markTestSkipped('Knp Markdown Bundle was not installed.');
         }
     }
 

--- a/tests/SilexExtension/Tests/MemcacheExtensionTest.php
+++ b/tests/SilexExtension/Tests/MemcacheExtensionTest.php
@@ -12,6 +12,9 @@ class MemcacheExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
+        if (!class_exists('Memcache')) {
+            $this->markTestSkipped('Memcache is not loaded.');
+        }
         if (!class_exists('Memcached')) {
             $this->markTestSkipped('Memcached is not loaded.');
         }

--- a/tests/SilexExtension/Tests/MongoDbExtensionTest.php
+++ b/tests/SilexExtension/Tests/MongoDbExtensionTest.php
@@ -12,7 +12,7 @@ class MongoDbExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        if (!is_dir(__DIR__ . '/../../../vendor/mongodb/lib')) {
+        if (!class_exists('Doctrine\\MongoDB\\Connection')) {
             $this->markTestSkipped('Doctrine\MongoDB was not installed.');
         }
     }
@@ -86,9 +86,10 @@ class MongoDbExtensionTest extends \PHPUnit_Framework_TestCase
         
         $mongo = $app['mongodb']->getMongo();
         $reflect  = new \ReflectionClass($mongo);
-        $property = $reflect->getProperty('persistent');
+        
+        $property = $reflect->getProperty('connected');
         $property->setAccessible(true);
-        $this->assertSame('c83d9d59bf24ae3a6dc5a30cb47ebbba', $property->getValue($mongo));
+        $this->assertFalse($property->getValue($mongo));
     }
     
     

--- a/tests/SilexExtension/Tests/PredisExtensionTest.php
+++ b/tests/SilexExtension/Tests/PredisExtensionTest.php
@@ -12,7 +12,7 @@ class PredisExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        if (!is_dir(__DIR__ . '/../../../vendor/predis/lib')) {
+        if (!class_exists('Predis\\Client')) {
             $this->markTestSkipped('Predis was not installed.');
         }
     }
@@ -39,7 +39,7 @@ class PredisExtensionTest extends \PHPUnit_Framework_TestCase
     
     /**
      *
-     * @expectedException Predis\ConnectionException
+     * @expectedException Predis\Connection\ConnectionException
      */
     public function testFailedConnection()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,4 @@
 <?php
 
 require_once __DIR__ . '/../silex.phar';
-
-use Symfony\Component\ClassLoader\UniversalClassLoader;
-
-$loader = new UniversalClassLoader();
-$loader->registerNamespace('SilexExtension', __DIR__ . '/../src');
-$loader->register();
+require_once __DIR__ . '/../vendor/.composer/autoload.php';


### PR DESCRIPTION
For changes see complete commit message

To make it work nicely you would only have to merge it and create the package on
http://packagist.org/

Without packagist, there is no support for recursive requirements inside the other
librarys.

Will create composer-related pullrequests for mandango/mondator, mandango/mandango and fate/gravatar-php later, so the extra repository-declarations for those 3 requirements can be dropped from composer.json.

Travis-CI build can be seen here: http://travis-ci.org/#!/robo47/Silex-Extensions/builds/827860
