### PR TITLE
Fixes missing ServiceProviderInterface::boot() method

### DIFF
--- a/src/SilexExtension/AsseticExtension.php
+++ b/src/SilexExtension/AsseticExtension.php
@@ -16,6 +16,11 @@ use Assetic\AssetManager,
 
 class AsseticExtension implements ServiceProviderInterface
 {
+    public function boot(Application $app)
+    {
+
+    }
+
     public function register(Application $app)
     {
         $app['assetic.options'] = array_replace(array(

--- a/src/SilexExtension/EmbedlyExtension.php
+++ b/src/SilexExtension/EmbedlyExtension.php
@@ -12,6 +12,11 @@ use Embedly\Embedly,
 
 class EmbedlyExtension implements ServiceProviderInterface
 {
+    public function boot(Application $app)
+    {
+
+    }
+
     public function register(Application $app)
     {  
         $app['embedly'] = $app->share(function () use ($app) {

--- a/src/SilexExtension/GravatarExtension.php
+++ b/src/SilexExtension/GravatarExtension.php
@@ -13,6 +13,11 @@ use Gravatar\Service,
 
 class GravatarExtension implements ServiceProviderInterface
 {
+    public function boot(Application $app)
+    {
+
+    }
+
     public function register(Application $app)
     {  
         $app['gravatar'] = $app->share(function () use ($app) {

--- a/src/SilexExtension/MandangoExtension.php
+++ b/src/SilexExtension/MandangoExtension.php
@@ -13,6 +13,11 @@ use Mandango\Mandango,
 use Mandango\Mondator\Mondator;
 class MandangoExtension implements ServiceProviderInterface
 {
+    public function boot(Application $app)
+    {
+
+    }
+
     public function register(Application $app)
     {  
                  

--- a/src/SilexExtension/MarkdownExtension.php
+++ b/src/SilexExtension/MarkdownExtension.php
@@ -11,6 +11,11 @@ use SilexExtension\MarkdownExtension\MarkdownTwigExtension;
 
 class MarkdownExtension implements ServiceProviderInterface
 {
+    public function boot(Application $app)
+    {
+
+    }
+
     public function register(Application $app)
     {
         $app['markdown'] = $app->share(function () use ($app) {

--- a/src/SilexExtension/MemcacheExtension.php
+++ b/src/SilexExtension/MemcacheExtension.php
@@ -9,6 +9,11 @@ use Silex\ServiceProviderInterface;
 
 class MemcacheExtension implements ServiceProviderInterface
 {
+    public function boot(Application $app)
+    {
+
+    }
+
     public function register(Application $app)
     {  
         $app['memcache'] = $app->share(function () use ($app) {

--- a/src/SilexExtension/MongoDbExtension.php
+++ b/src/SilexExtension/MongoDbExtension.php
@@ -12,6 +12,11 @@ use Doctrine\MongoDB\Connection,
 
 class MongoDbExtension implements ServiceProviderInterface
 {
+    public function boot(Application $app)
+    {
+
+    }
+
     public function register(Application $app)
     {   
         /**

--- a/src/SilexExtension/PredisExtension.php
+++ b/src/SilexExtension/PredisExtension.php
@@ -13,6 +13,11 @@ use Predis\Client,
 
 class PredisExtension implements ServiceProviderInterface
 {
+    public function boot(Application $app)
+    {
+
+    }
+
     public function register(Application $app)
     {  
         $app['predis'] = $app->share(function () use ($app) {


### PR DESCRIPTION
Fixes missing ServiceProviderInterface::boot() method
see https://github.com/fabpot/Silex/pull/330
