### PR TITLE
Added missing bootstrap method per ServiceProviderInterface definition...

### DIFF
--- a/src/SilexExtension/AsseticExtension.php
+++ b/src/SilexExtension/AsseticExtension.php
@@ -135,4 +135,13 @@ class AsseticExtension implements ServiceProviderInterface
             $app['autoloader']->registerNamespace('Assetic', $app['assetic.class_path']);
         }
     }
+
+    /**
+     * Bootstraps the application.
+     *
+     * @param \Silex\Application $app The application
+     */
+    function boot(Application $app)
+    {
+    }
 }


### PR DESCRIPTION
As `ServiceProviderInterface` defines, there is now a mising method in the current definition of the `AsseticExtension` that prevents any project using it from working.
