### PR TITLE
Also dump assets defined in twig templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
     },
     "suggest": {
         "kriswallsmith/assetic": ">=1.0",
+        "symfony/finder": "2.1.*",
         "twig/twig": ">=1.2.0",
         "doctrine/mongodb": "*",
         "predis/predis": "*",

--- a/doc/assetic.rst
+++ b/doc/assetic.rst
@@ -18,6 +18,9 @@ Parameters
   will cache assets generated trough formulae in this folder to improve performance. Remember,
   assets added trough the AssetManager need to care about their own cache.
 
+* **assetic.options => auto_dump_assets** (defaults to true,optional): Whether to write all the assets
+  to filesystem on every request.
+
 * **assetic.class_path** (optional): Path to where the Assetic
   library is located.
 

--- a/doc/assetic.rst
+++ b/doc/assetic.rst
@@ -65,6 +65,9 @@ Services
         array('output' => 'css/extra')  
     ));
 
+* **assetic.helper**:  Instance of SilexExtension\Helper\Assetic. Contains methods
+  to dump assets.
+  
 Registering
 -----------
 

--- a/doc/assetic.rst
+++ b/doc/assetic.rst
@@ -65,7 +65,7 @@ Services
         array('output' => 'css/extra')  
     ));
 
-* **assetic.helper**:  Instance of SilexExtension\Helper\Assetic. Contains methods
+* **assetic.dumper**:  Instance of SilexExtension\Assetic\Dumper. Contains methods
   to dump assets.
   
 Registering

--- a/src/SilexExtension/Assetic/Dumper.php
+++ b/src/SilexExtension/Assetic/Dumper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilexExtension\Dumper;
+namespace SilexExtension\Assetic;
 
 use Symfony\Component\Finder\Finder;
 

--- a/src/SilexExtension/Assetic/Dumper.php
+++ b/src/SilexExtension/Assetic/Dumper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilexExtension\Helper;
+namespace SilexExtension\Dumper;
 
 use Symfony\Component\Finder\Finder;
 
@@ -9,7 +9,7 @@ use Assetic\Factory\LazyAssetManager,
     Assetic\AssetManager,
     Assetic\Extension\Twig\TwigResource;
 
-class Assetic
+class Dumper
 {
     /**
      * @var AssetManager

--- a/src/SilexExtension/AsseticExtension.php
+++ b/src/SilexExtension/AsseticExtension.php
@@ -2,7 +2,7 @@
 
 namespace SilexExtension;
 
-use SilexExtension\Helper\Assetic;
+use SilexExtension\Assetic\Dumper;
 
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -62,7 +62,7 @@ class AsseticExtension implements ServiceProviderInterface
                 return;
             }
             
-            $helper = $app['assetic.helper'];
+            $helper = $app['assetic.dumper'];
             if (isset($app['twig'])) {
                 $helper->addTwigAssets();
             }
@@ -133,8 +133,8 @@ class AsseticExtension implements ServiceProviderInterface
             return $lazy;
         });
         
-        $app['assetic.helper'] = $app->share(function () use ($app) {
-            return new Assetic($app['assetic.asset_manager'], $app['assetic.lazy_asset_manager'], $app['assetic.asset_writer']);
+        $app['assetic.dumper'] = $app->share(function () use ($app) {
+            return new Dumper($app['assetic.asset_manager'], $app['assetic.lazy_asset_manager'], $app['assetic.asset_writer']);
         });
 
         if(isset($app['twig'])) {
@@ -148,7 +148,7 @@ class AsseticExtension implements ServiceProviderInterface
                 return $am;
             }));
             
-            $app['assetic.helper'] = $app->share($app->extend('assetic.helper', function ($helper, $app) {
+            $app['assetic.dumper'] = $app->share($app->extend('assetic.dumper', function ($helper, $app) {
                 $helper->setTwig($app['twig'], $app['twig.loader.filesystem']);
                 return $helper;
             }));     

--- a/src/SilexExtension/AsseticExtension.php
+++ b/src/SilexExtension/AsseticExtension.php
@@ -24,6 +24,7 @@ class AsseticExtension implements ServiceProviderInterface
         $app['assetic.options'] = array_replace(array(
             'debug' => false,
             'formulae_cache_dir' => null,
+            'auto_dump_assets' => true,
         ), isset($app['assetic.options']) ? $app['assetic.options'] : array());
 
         /**
@@ -52,14 +53,17 @@ class AsseticExtension implements ServiceProviderInterface
             $factory->setFilterManager($app['assetic.filter_manager']);
             return $factory;
         });
-        
+
         /**
          * Writes down all lazy asset manager and asset managers assets
          */
         $app->after(function() use ($app) {
-            $helper = $app['assetic.helper'];
+            if (false === $app['assetic.options']['auto_dump_assets']) {
+                return;
+            }
             
-            if (true === $app['assetic.options']['debug'] && isset($app['twig'])) {
+            $helper = $app['assetic.helper'];
+            if (isset($app['twig'])) {
                 $helper->addTwigAssets();
             }
             

--- a/src/SilexExtension/AsseticExtension.php
+++ b/src/SilexExtension/AsseticExtension.php
@@ -60,10 +60,10 @@ class AsseticExtension implements ServiceProviderInterface
         $self = $this;
         $app->after(function() use ($app, $self) {
             if (true === $app['assetic.options']['debug'] && isset($app['twig'])) {
-                $self->addTwigAssets($app['assetic.lazy_asset_manager'], $app['twig'], $app['twig.loader.filesystem']);
+                $self::addTwigAssets($app['assetic.lazy_asset_manager'], $app['twig'], $app['twig.loader.filesystem']);
             }
-            $self->dumpAssets($app['assetic.lazy_asset_manager'], $app['assetic.asset_writer']);
-            $self->dumpAssets($app['assetic.asset_manager'],      $app['assetic.asset_writer']);
+            $self::dumpAssets($app['assetic.lazy_asset_manager'], $app['assetic.asset_writer']);
+            $self::dumpAssets($app['assetic.asset_manager'],      $app['assetic.asset_writer']);
         });
 
         /**
@@ -144,7 +144,7 @@ class AsseticExtension implements ServiceProviderInterface
      * @param \Twig_Environment        $twig
      * @param \Twig_Loader_Filesystem  $loader
      */
-    public function addTwigAssets(LazyAssetManager $am, \Twig_Environment $twig, \Twig_Loader_Filesystem $loader)
+    public static function addTwigAssets(LazyAssetManager $am, \Twig_Environment $twig, \Twig_Loader_Filesystem $loader)
     {
         $am->setLoader('twig', new TwigFormulaLoader($twig));
         
@@ -166,7 +166,7 @@ class AsseticExtension implements ServiceProviderInterface
      * @param AssetManager $am
      * @param AssetWriter  $writer
      */
-    public function dumpAssets(AssetManager $am, AssetWriter $writer)
+    public static function dumpAssets(AssetManager $am, AssetWriter $writer)
     {
         foreach ($am->getNames() as $name) {
             $asset   = $am->get($name);
@@ -185,7 +185,7 @@ class AsseticExtension implements ServiceProviderInterface
                 foreach ($asset as $leaf) {
                     $writer->writeAsset($leaf);
                 } 
-            }    
+            }
         }
     }
     

--- a/src/SilexExtension/Helper/Assetic.php
+++ b/src/SilexExtension/Helper/Assetic.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace SilexExtension\Helper;
+
+use Symfony\Component\Finder\Finder;
+
+use Assetic\Factory\LazyAssetManager,
+    Assetic\AssetWriter,
+    Assetic\AssetManager,
+    Assetic\Extension\Twig\TwigResource;
+
+class Assetic
+{
+    /**
+     * @var AssetManager
+     */
+    protected $am;
+    /**
+     * @var AssetWriter
+     */
+    protected $writer;
+    /**
+     * @var LazyAssetManager
+     */
+    protected $lam;
+    /** 
+     * @var \Twig_Environment
+     */
+    protected $twig;
+    
+    /** 
+     * @var \Twig_Loader_Filesystem
+     */
+    protected $loaders;
+   
+    /**
+     * Ctor
+     * 
+     * @param AssetManager     $am
+     * @param LazyAssetManager $lam
+     * @param AssetWriter      $writer
+     */
+    public function __construct(AssetManager $am, LazyAssetManager $lam, AssetWriter $writer)
+    {
+        $this->am     = $am;
+        $this->lam    = $lam;
+        $this->writer = $writer;
+    }
+    
+    /**
+     * @param \Twig_Environment       $twig
+     * @param \Twig_Loader_Filesystem $loader
+     */
+    public function setTwig(\Twig_Environment $twig, \Twig_Loader_Filesystem $loader) 
+    {
+        $this->twig   = $twig;
+        $this->loader = $loader;
+    }
+    
+    /**
+     * Locates twig templates and adds their defined assets to the lazy asset manager
+     */
+    public function addTwigAssets()
+    {
+        if (!$this->twig instanceof \Twig_Environment) {
+            throw new \LogicException('Twig environment not set'); 
+        }
+        
+        $finder   = new Finder();
+        $iterator = $finder->files()->name('*.twig')->in($this->loader->getPaths());
+        
+        foreach ($iterator as $file) {
+            $resource = new TwigResource($this->loader, $file->getRelativePathname());
+            $this->lam->addResource($resource, 'twig');
+        }
+    }
+    
+    /**
+     * Dumps all the assets 
+     */
+    public function dumpAssets() 
+    {
+        $this->dumpManagerAssets($this->am);
+        $this->dumpManagerAssets($this->lam);
+    }
+    
+    /**
+     * Dumps the assets of given manager
+     * 
+     * Doesn't use AssetWriter::writeManagerAssets since we also want to dump non-combined assets 
+     * (for example, when using twig extension in debug mode).
+     * 
+     * @param AssetManager $am
+     * @param AssetWriter  $writer
+     */
+    protected function dumpManagerAssets(AssetManager $am)
+    {
+        foreach ($am->getNames() as $name) {
+            $asset   = $am->get($name);
+            
+            $formula = $am->getFormula($name);
+            
+            $this->writer->writeAsset($asset);
+            
+            if (!isset($formula[2])) {
+                continue;
+            }
+            
+            $debug   = isset($formula[2]['debug'])   ? $formula[2]['debug']   : $am->isDebug();
+            $combine = isset($formula[2]['combine']) ? $formula[2]['combine'] : null;
+            
+            if (null !== $combine ? !$combine : $debug) {
+                foreach ($asset as $leaf) {
+                    $this->writer->writeAsset($leaf);
+                } 
+            }
+        }
+    }
+}


### PR DESCRIPTION
Now also dumps (but only in `debug` mode) assets defined in twig templates.

Rewritten the dumping a bit because `AssetWriter::writeManagerAssets` doesn't look at non-combined assets (which is the case when you use twig in debug mode).
