### PR TITLE
Add md extension only when twig is called

### DIFF
--- a/src/SilexExtension/MarkdownExtension.php
+++ b/src/SilexExtension/MarkdownExtension.php
@@ -24,7 +24,10 @@ class MarkdownExtension implements ServiceProviderInterface
         });
 
         if (isset($app['twig'])) {
-            $app['twig']->addExtension(new MarkdownTwigExtension($app['markdown']));
+            $app['twig'] = $app->share($app->extend('twig', function ($twig, $app) {
+                $twig->addExtension(new MarkdownTwigExtension($app['markdown']));
+                return $twig;
+            }));
         }
     }
 }


### PR DESCRIPTION
Accessing `twig` service during `register` might lead to unexpected results. 

For example, when using _form_ and _csrf_ this will fire up a session while it may not be used.
